### PR TITLE
Adds support for headers:false to get arrays

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "excel-stream",
   "description": "convert a stream of xls or xlsx into json on the command line or in node",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "bin": "index.js",
   "homepage": "https://github.com/dominictarr/excel-stream",
   "repository": {


### PR DESCRIPTION
#### Changes
- Allows mapping of an array or an object
- Increment version, this should have been done earlier because changing to `fast-csv` is a breaking change where the person needed to pass the option `header: true` to keep the old functionality. Now the default maps to the `fast-csv` defaults meaning its defaulting to arrays not objects with expected header